### PR TITLE
Fixed example

### DIFF
--- a/views/index.erb
+++ b/views/index.erb
@@ -93,8 +93,8 @@ $ pod setup
 <pre class="prettyprint">
 $ edit Podfile
 platform :ios
-dependency 'JSONKit',       '~> 1.4'
-dependency 'Reachability',  '~> 3.0.0'
+pod 'JSONKit',       '~> 1.4'
+pod 'Reachability',  '~> 3.0.0'
 </pre>
 					<p>
 						Now you can install the dependencies in your project:


### PR DESCRIPTION
Example now shows how to list dependencies using 'pod' instead of 'dependency' 
