### PR TITLE
Better import explanation

### DIFF
--- a/views/index.haml
+++ b/views/index.haml
@@ -99,6 +99,10 @@
 						file when building your project:
 					%pre.prettyprint
 						$ open App.xcworkspace
+					%p
+						Now you can import your dependencies e.g.:
+					%pre.prettyprint
+						#import <Reachability.h>
 					%h3 How to create a pod
 					%p
 						Sometimes CocoaPods doesn’t yet have a pod for one of your dependencies. 


### PR DESCRIPTION
It took me 2 hours and a lot of searches before finding a sample project showing me the right way of importing..

If the regular import "Reachability.h" does not working, search does not really help and only brings up topics like this one: 

http://stackoverflow.com/questions/12002905/ios-build-fails-with-cocoapods-cannot-find-header-files
