### PR TITLE
Removes square brackets around [sudo] in install instructions; replaces with comment

### DIFF
--- a/views/index.haml
+++ b/views/index.haml
@@ -71,7 +71,7 @@
 						installing it is as easy as running the following commands in the terminal:
 					%pre.prettyprint
 						:preserve
-							$ gem install cocoapods # You may need `sudo gem install cocoapods'
+							$ gem install cocoapods # You may need: sudo gem install cocoapods
 							$ pod setup
 					%p
 						Now that you’ve got CocoaPods installed it’s time to 


### PR DESCRIPTION
So far I've seen three times where someone leaves in the square brackets around [sudo] in the instructions. This [morning's closed issue](https://github.com/CocoaPods/cocoapods.github.com/issues/24), once when watching a designer install Cocoapods, and once when I was installing it on a new computer.

To solve this, I changed it from
`$ [sudo] gem install cocoapods`
to

```
$ gem install cocoapods # You may need: sudo gem install cocoapods
```

Testing:
If you merge this, this would be the longest preformatted text on the page, but it didn't extend past the page on an iPhone 4 (portrait) or on my Macbook pro. It's possible it would extend past the page on even smaller phones, in which case maybe I should enable text wrapping in the `pre` section of the SCSS?
