### PR TITLE
Added a version to basic config example

### DIFF
--- a/views/index.haml
+++ b/views/index.haml
@@ -21,7 +21,7 @@
 	%pre.prettyprint
 		:preserve
 			$ edit Podfile
-			platform :ios
+			platform :ios, '6.0'
 			pod 'JSONKit',       '~> 1.4'
 			pod 'Reachability',  '~> 3.0.0'
 	%p


### PR DESCRIPTION
I'm brand new to CocoaPod and the setup was very slick. However, when I tried to install my deps I got a seemingly strange error telling me that I was using iOS 4.3, while in reality I'm on 6.1. Please accept this pull request and make it very obvious how you set the platform version. It will be a much better first experience.
