### PR TITLE
Use CocoaPods core for version resolution

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,6 +17,7 @@ gem 'picky-client', '~> 4.31.0' # Needed for Picky::Convenience
 gem 'cod', '0.6.0'
 gem 'hashie', '3.3.2'
 # gem 'google_hash', '0.8.8'
+gem 'cocoapods-core', "~> 1.0"
 
 # Auxiliary gems to make Picky faster/better.
 #
@@ -32,7 +33,7 @@ gem 'flounder', '1.0.1'
 
 # API calling.
 #
-gem 'nap', '~> 0.8.0'
+gem 'nap', '~> 1.0'
 
 # Pure development gems.
 #
@@ -47,6 +48,7 @@ end
 group :production do
   gem 'unicorn', '4.8.3'
 end
+
 
 # Pure test gems.
 #

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,9 +9,8 @@ GIT
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (4.2.3)
+    activesupport (4.2.10)
       i18n (~> 0.7)
-      json (~> 1.7, >= 1.7.7)
       minitest (~> 5.1)
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
@@ -20,9 +19,14 @@ GEM
     arel (5.0.1.20140414130214)
     ast (2.3.0)
     bacon (1.2.0)
+    cocoapods-core (1.5.0)
+      activesupport (>= 4.0.2, < 6)
+      fuzzy_match (~> 2.0.4)
+      nap (~> 1.0)
     cocoapods-humus (0.1.0)
       s3 (~> 0.3)
     cod (0.6.0)
+    concurrent-ruby (1.0.5)
     connection_pool (2.1.3)
     data_objects (0.10.14)
       addressable (~> 2.1)
@@ -49,9 +53,10 @@ GEM
     foreman (0.75.0)
       dotenv (~> 0.11.1)
       thor (~> 0.19.1)
+    fuzzy_match (2.0.4)
     hashie (3.3.2)
-    i18n (0.7.0)
-    json (1.8.3)
+    i18n (0.9.5)
+      concurrent-ruby (~> 1.0)
     kgio (2.9.2)
     kicker (3.0.0)
       listen (~> 1.3.0)
@@ -62,13 +67,13 @@ GEM
       rb-kqueue (>= 0.2)
     memory_profiler (0.9.4)
     metaclass (0.0.4)
-    minitest (5.7.0)
+    minitest (5.11.3)
     mocha (0.11.4)
       metaclass (~> 0.0.1)
     mocha-on-bacon (0.2.1)
       mocha (>= 0.9.8)
     multi_json (1.11.2)
-    nap (0.8.0)
+    nap (1.1.0)
     notify (0.5.2)
     parser (2.3.3.1)
       ast (~> 2.2)
@@ -113,9 +118,9 @@ GEM
       rack-protection (~> 1.4)
       tilt (~> 1.3, >= 1.3.4)
     thor (0.19.1)
-    thread_safe (0.3.5)
+    thread_safe (0.3.6)
     tilt (1.4.1)
-    tzinfo (1.2.2)
+    tzinfo (1.2.5)
       thread_safe (~> 0.1)
     unicode-display_width (1.1.2)
     unicorn (4.8.3)
@@ -131,6 +136,7 @@ PLATFORMS
 DEPENDENCIES
   bacon
   bundler
+  cocoapods-core (~> 1.0)
   cocoapods-humus
   cod (= 0.6.0)
   dm-postgres-adapter (= 1.2.0)
@@ -141,7 +147,7 @@ DEPENDENCIES
   memory_profiler
   mocha (~> 0.11.4)
   mocha-on-bacon
-  nap (~> 0.8.0)
+  nap (~> 1.0)
   pg (= 0.18.1)
   picky (~> 4.31.0)
   picky-client (~> 4.31.0)
@@ -156,4 +162,4 @@ DEPENDENCIES
   yajl-ruby
 
 BUNDLED WITH
-   1.13.6
+   1.15.4

--- a/lib/models/pod.rb
+++ b/lib/models/pod.rb
@@ -1,9 +1,10 @@
 # frozen_string_literal: true
 require 'json'
+require 'cocoapods-core'
 
 # Only for reading purposes.
 #
-class Pod
+class SearchPod
   attr_reader :row, :versions
 
   DEFAULT_QUALITY = 40
@@ -47,7 +48,7 @@ class Pod
     entity.count
   end
 
-  # Use e.g. Pod.find.where(…).all
+  # Use e.g. SearchPod.find.where(…).all
   #
   def self.find
     pods = entity.
@@ -168,7 +169,7 @@ class Pod
   #
   def last_version
     versions.
-      sort_by { |v| Gem::Version.new(v) }.
+      sort_by { |v| Pod::Version.new(v) }.
       last.to_sym
   end
 
@@ -213,7 +214,7 @@ class Pod
   end
   def symbolize_hash hash
     hash.inject({}) do |result, (key, value)|
-      result.tap { |r| r[key.to_sym] = (value && value.to_sym) }
+      result.tap { |r| r[key.to_sym] = (value && !value.is_a?(Array) && value.to_sym) }
     end
   end
 

--- a/lib/pods.rb
+++ b/lib/pods.rb
@@ -14,7 +14,7 @@ class Pods
   end
   
   def count
-    @count ||= Pod.count
+    @count ||= SearchPod.count
   end
 
   # Pods are ordered by popularity initially.
@@ -29,7 +29,7 @@ class Pods
       )
     EXPR
 
-    pods = Pod.all do |all_pods|
+    pods = SearchPod.all do |all_pods|
       all_pods.order_by(order_by_popularity)
       all_pods.limit(amount) if amount
       all_pods
@@ -61,7 +61,7 @@ class Pods
   #
   def for(all_ids)
     uncached_ids = all_ids.reject { |id| @cache[id] }
-    loaded_pods = Pod.all do |pods|
+    loaded_pods = SearchPod.all do |pods|
       pods.where(Domain.pods[:id].in => uncached_ids)
     end
     loaded_pods.each { |pod| @cache[pod.id] = pod }

--- a/lib/search.rb
+++ b/lib/search.rb
@@ -224,7 +224,7 @@ class Search
   # Try indexing a new pod.
   #
   def reindex(name)
-    pod = Pod.all { |pods| pods.where(name: name) }.first
+    pod = SearchPod.all { |pods| pods.where(name: name) }.first
     replace pod, Pods.instance
     pod.release_indexing_memory
     $stdout.print ?✓

--- a/spec/api/flat_ids_integration_spec.rb
+++ b/spec/api/flat_ids_integration_spec.rb
@@ -83,7 +83,7 @@ describe 'Flat Ids Integration Tests' do
   #
   # Platform is only found when fully mentioned (i.e. no partial).
   #
-  ok { pods.search('platform:osx', ids: 10_000).size.should == 87 }
+  ok { pods.search('platform:osx', ids: 10_000).size.should == 86 }
   ok { pods.search('platform:os').size.should == 0 }
   ok { pods.search('platform:o').size.should == 0 }
 
@@ -108,8 +108,8 @@ describe 'Flat Ids Integration Tests' do
   ok { first_three_names_for_search('use:AFNetworking', sort: 'name').should == expected_dependencies }
   ok { first_three_names_for_search('needs:AFNetworking', sort: 'name').should == expected_dependencies }
 
-  ok { pods.search('platform:osx', ids: 10_000).size.should == 87 }
-  ok { pods.search('on:osx', ids: 10_000).size.should == 87 }
+  ok { pods.search('platform:osx', ids: 10_000).size.should == 86 }
+  ok { pods.search('on:osx', ids: 10_000).size.should == 86 }
 
   # Stemming.
   #

--- a/spec/api/picky_integration_spec.rb
+++ b/spec/api/picky_integration_spec.rb
@@ -80,7 +80,7 @@ describe 'Integration Tests' do
   #
   # Platform is only found when fully mentioned (i.e. no partial).
   #
-  ok { pods.search('platform:osx').total.should == 87 }
+  ok { pods.search('platform:osx').total.should == 86 }
   ok { pods.search('platform:os').total.should == 0 }
   ok { pods.search('platform:o').total.should == 0 }
 
@@ -112,8 +112,8 @@ describe 'Integration Tests' do
   ok { first_three_names_for_search('use:AFNetworking', sort: 'name').should == expected_dependencies }
   ok { first_three_names_for_search('needs:AFNetworking', sort: 'name').should == expected_dependencies }
 
-  ok { pods.search('platform:osx').total.should == 87 }
-  ok { pods.search('on:osx').total.should == 87 }
+  ok { pods.search('platform:osx').total.should == 86 }
+  ok { pods.search('on:osx').total.should == 86 }
 
   ok { first_three_names_for_search('summary:data', sort: 'name').should == %w(IGListKit JSONModel MagicalRecord) }
 

--- a/spec/lib/models/pod_spec.rb
+++ b/spec/lib/models/pod_spec.rb
@@ -8,7 +8,7 @@ describe Pod do
     
     describe 'deprecated_in_favor_of set' do
       def pod
-        af = Pod.new({})
+        af = SearchPod.new({})
         class << af
           def specification
             {
@@ -27,7 +27,7 @@ describe Pod do
     
     describe 'deprecated_in_favor_of not set' do
       def pod
-        af = Pod.new({})
+        af = SearchPod.new({})
         class << af
           def specification
             {
@@ -45,7 +45,7 @@ describe Pod do
     
     describe '#split_name' do
       def pod
-        @pod ||= Pod.new({})
+        @pod ||= SearchPod.new({})
       end
 
       def ok_split pod_name, *expected

--- a/spec/lib/models/pod_with_db_spec.rb
+++ b/spec/lib/models/pod_with_db_spec.rb
@@ -7,7 +7,7 @@ describe Pod do
   describe 'AFNetworking' do
 
     def pod
-      Pod.all { |pods| pods.where(name: 'AFNetworking') }.first
+      SearchPod.all { |pods| pods.where(name: 'AFNetworking') }.first
     end
 
     ok { pod.name.should == 'AFNetworking' }
@@ -67,7 +67,7 @@ describe Pod do
   describe 'KGDiscreetAlertView' do
 
     def pod
-      Pod.all { |pods| pods.where(name: 'KGDiscreetAlertView') }.first
+      SearchPod.all { |pods| pods.where(name: 'KGDiscreetAlertView') }.first
     end
 
     ok { pod.platforms.should == [:ios] }
@@ -78,7 +78,7 @@ describe Pod do
   describe 'CCLDefaults' do
 
     def pod
-      Pod.all { |pods| pods.where(name: 'CCLDefaults') }.first
+      SearchPod.all { |pods| pods.where(name: 'CCLDefaults') }.first
     end
 
     ok { pod.mapped_authors.should == 'Kyle Fuller' }
@@ -88,7 +88,7 @@ describe Pod do
   describe 'QueryKit' do
 
     def pod
-      Pod.all { |pods| pods.where(name: 'QueryKit') }.first
+      SearchPod.all { |pods| pods.where(name: 'QueryKit') }.first
     end
 
     ok { pod.mapped_authors.should == 'Kyle Fuller' }
@@ -98,7 +98,7 @@ describe Pod do
   describe 'synthetic case #1' do
     
     def pod
-      af = Pod.all { |pods| pods.where(name: 'AFNetworking') }.first
+      af = SearchPod.all { |pods| pods.where(name: 'AFNetworking') }.first
       class << af
         def source
           { http: 'http://parse-ios.s3.amazonaws.com/d9dd1242464f5bb586d9f8d660045c04/parse-library-1.6.2.zip' }
@@ -116,7 +116,7 @@ describe Pod do
   describe 'synthetic case #2' do
     
     def pod
-      af = Pod.all { |pods| pods.where(name: 'AFNetworking') }.first
+      af = SearchPod.all { |pods| pods.where(name: 'AFNetworking') }.first
       class << af
         def source
           { git: "https://github.com/tibo/BlockRSSParser.git" }
@@ -134,7 +134,7 @@ describe Pod do
   describe 'synthetic case #3' do
     
     def pod
-      af = Pod.all { |pods| pods.where(name: 'AFNetworking') }.first
+      af = SearchPod.all { |pods| pods.where(name: 'AFNetworking') }.first
       class << af
         def source
           { git: "git://github.com/OliverLetterer/GHMarkdownParser.git" }
@@ -152,7 +152,7 @@ describe Pod do
   describe 'synthetic case #4' do
     
     def pod
-      af = Pod.all { |pods| pods.where(name: 'AFNetworking') }.first
+      af = SearchPod.all { |pods| pods.where(name: 'AFNetworking') }.first
       class << af
         def source
           { http: "http://sourceforge.net/projects/uriparser/files/Sources/0.7.7/uriparser-0.7.7.zip" }
@@ -170,7 +170,7 @@ describe Pod do
   describe 'synthetic case #5' do
     
     def pod
-      af = Pod.all { |pods| pods.where(name: 'AFNetworking') }.first
+      af = SearchPod.all { |pods| pods.where(name: 'AFNetworking') }.first
       class << af
         def source
           { http: "http://sourceforge.net/projects/uriparser/files/Sources/0.7.7/uriparser-0.7.7.zip" }
@@ -188,7 +188,7 @@ describe Pod do
   describe 'synthetic case #5' do
     
     def pod
-      af = Pod.all { |pods| pods.where(name: 'AFNetworking') }.first
+      af = SearchPod.all { |pods| pods.where(name: 'AFNetworking') }.first
       class << af
         def source
           nil
@@ -206,7 +206,7 @@ describe Pod do
   describe 'synthetic case #6' do
       
     def pod
-      af = Pod.all { |pods| pods.where(name: 'AFNetworking') }.first
+      af = SearchPod.all { |pods| pods.where(name: 'AFNetworking') }.first
       class << af
         def homepage
           'https://www.github.com/venmo/VENTouchLock'

--- a/spec/lib/search_spec.rb
+++ b/spec/lib/search_spec.rb
@@ -97,11 +97,11 @@ describe Search do
       pods = Pods.new
       search = Search.new
 
-      old_pod = Pod.new(specification)
+      old_pod = SearchPod.new(specification)
 
       pods[old_pod.id].should.nil?
 
-      new_pod = Pod.new(specification)
+      new_pod = SearchPod.new(specification)
 
       search.replace(new_pod, pods) rescue nil
 

--- a/spec/special_cases_spec.rb
+++ b/spec/special_cases_spec.rb
@@ -74,7 +74,7 @@ describe 'Special Cases' do
   end
 
   def with_pod_added(name, &block)
-    pod = Pod.all { |pods| pods.where(name: name) }.first
+    pod = SearchPod.all { |pods| pods.where(name: name) }.first
     Search.instance.replace(pod, Pods.instance)
 
     block.call(pod)


### PR DESCRIPTION
`Gem::Version` and `Pod::Version` support different rules, and Gem::Version was crashing -  did this take the server down? unsure, but it does mean that now you can actually run a copy of the search locally